### PR TITLE
Remove redundant code

### DIFF
--- a/include/ring_buffer.h
+++ b/include/ring_buffer.h
@@ -52,9 +52,4 @@ bool slf_log_store_get(GglBuffer *log, uint64_t *timestamp);
 /// call to this function per call to slf_log_store_get
 void slf_log_store_remove(void);
 
-/// @brief Cleans up ring buffer resources including file descriptor and memory
-/// mappings. This function should be called when the ring buffer is no longer
-/// needed to prevent resource leaks.
-void slf_cleanup_ringbuf_state(void);
-
 #endif

--- a/src/system-log-forwarder.c
+++ b/src/system-log-forwarder.c
@@ -201,7 +201,6 @@ static GglError producer_thread(Config config) {
 
     GglError setup_ret = setup_journal(&journal);
     if (setup_ret != GGL_ERR_OK) {
-        slf_cleanup_ringbuf_state();
         return setup_ret;
     }
 
@@ -221,7 +220,6 @@ static GglError producer_thread(Config config) {
     }
 
     sd_journal_close(journal);
-    slf_cleanup_ringbuf_state();
     return GGL_ERR_OK;
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The code is redundant as on the case ring buffer allocation fails we directly exit the program after with an operating system can guarantee the cleanup

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
