### PR TITLE
Fix excessive logging on a loop when there are no logs to upload

### DIFF
--- a/src/ring_buffer.c
+++ b/src/ring_buffer.c
@@ -216,7 +216,7 @@ void slf_log_store_wait_for_upload_trigger(time_t timeout_sec) {
         wait_result
             = pthread_cond_timedwait(&upload_cond, &upload_mutex, &timeout);
         if (wait_result == ETIMEDOUT) {
-            GGL_LOGW("Timed out waiting for a upload.");
+            GGL_LOGI("Timed out waiting for a upload.");
             break;
         }
     }

--- a/src/system-log-forwarder.c
+++ b/src/system-log-forwarder.c
@@ -152,10 +152,9 @@ static void *consumer_thread(void *arg) {
             ret = slf_upload_and_reset(
                 &upload_doc, &number_of_logs_added, config
             );
-            if (ret == GGL_ERR_OK) {
-                last_uploaded = time(NULL);
-            }
         }
+
+        last_uploaded = now;
 
         if (ret != GGL_ERR_OK) {
             GGL_LOGE(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
